### PR TITLE
Correção do exemplo `x < y`

### DIFF
--- a/5-PROGRAMACAO-BASICA.ipynb
+++ b/5-PROGRAMACAO-BASICA.ipynb
@@ -32,7 +32,7 @@
     "Operadores de comparação para determinar, por exemplo, se são iguais. Todos os operadores de comparação da JULIA retornam TRUE como verdade e FALSE como falso.\n",
     "Resumo:\n",
     "\n",
-    "* x; y     verdade se x é menor que y.\n",
+    "* x < y     verdade se x é menor que y.\n",
     "\n",
     "* x <= y   verdade se x é menor ou igual a y.\n",
     "\n",


### PR DESCRIPTION
Há um error no inicio do tutorial de programação básica nos exemplos de operadores lógicos.

Há também alguns erros de formação mais embaixo, mas vou logo tirar este mais simples do caminho e depois dou uma olhada mais aprofundada :P
